### PR TITLE
Don't parse x3B in first pass

### DIFF
--- a/src/lib/parser/parser.cpp
+++ b/src/lib/parser/parser.cpp
@@ -429,13 +429,10 @@ uint32_t parse_x36(File<A_174>& fs, void*& address) {
 
 template <AllegroVersion version>
 uint32_t parse_x3B(File<A_174>& fs, void*& address) {
-    x3B<version> x3B_inst;
-    memcpy(&x3B_inst, address, sizeof_until_tail<x3B<version>>());
-    skip(address, sizeof_until_tail<x3B<version>>());
+    x3B<version>* i = (x3B<version>*)address;
 
-    uint32_t len = round_to_word(x3B_inst.len);
-    x3B_inst.model_str = std::string((char*)address);
-    skip(address, len);
+    skip(address, sizeof_until_tail<x3B<version>>());
+    skip(address, round_to_word(i->len));
 
     return 0;
 }


### PR DESCRIPTION
We only need to know the length of the data to move on in the first pass.