### PR TITLE
Don't crash if x31 missing

### DIFF
--- a/src/brd_gui/brdview.cpp
+++ b/src/brd_gui/brdview.cpp
@@ -416,6 +416,10 @@ void BrdView::drawX30(const x30<A_175> *inst, QPen *pen) {
     }
     */
 
+    if (!fs->is_type(inst->str_graphic_ptr, 0x31)) {
+        return;
+    }
+
     const x31<A_175> &str_graphic = fs->get_x31(inst->str_graphic_ptr);
 
     QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);


### PR DESCRIPTION
Fix crash when drawing if `x31` is not present.