### PR TITLE
Use Windows 2019 runner only

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   windows-build:
     name: Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
The `windows-latest` version of MSVC is giving new issues that I am not interested in solving today.