### PR TITLE
Rename `x2B` to `T2BSymbol`

### DIFF
--- a/src/brd_gui/brdview.cpp
+++ b/src/brd_gui/brdview.cpp
@@ -359,7 +359,7 @@ void BrdView::drawX28(const T28Shape<kAMax> *inst, QPen *pen) {
   // }
 };
 
-void BrdView::drawX2B(const x2B<kAMax> *inst, QPen *pen) {
+void BrdView::drawX2B(const T2BSymbol<kAMax> *inst, QPen *pen) {
   // drawShape(inst->ptr2, pen);
   // drawShape(inst->ptr8, pen);
 }

--- a/src/brd_gui/brdview.h
+++ b/src/brd_gui/brdview.h
@@ -31,7 +31,7 @@ class BrdView : public QGraphicsView {
   void drawX17(const T17LineSegment<kAMax> *inst, QPainterPath *path);
   void drawX23(const T23Rat<kAMax> *inst, QPen *pen);
   void drawX28(const T28Shape<kAMax> *inst, QPen *pen);
-  void drawX2B(const x2B<kAMax> *inst, QPen *pen);
+  void drawX2B(const T2BSymbol<kAMax> *inst, QPen *pen);
   void drawX2D(const T2DSymbolInstance<kAMax> *inst, QPen *pen);
   void drawX30(const T30StringGraphic<kAMax> *inst, QPen *pen);
   void drawX32(const T32SymbolPin<kAMax> *inst, QPen *pen,

--- a/src/lib/parser/parser.h
+++ b/src/lib/parser/parser.h
@@ -137,7 +137,7 @@ const parser_t<version> PARSER_TABLE[] = {
     // 0x2A
     {&parse_x2A<version>},
     // 0x2B
-    {&default_parser<x2B, version>},
+    {&default_parser<T2BSymbol, version>},
     // 0x2C
     {&default_parser<x2C, version>},
     // 0x2D

--- a/src/lib/printing/printers.cpp
+++ b/src/lib/printing/printers.cpp
@@ -1852,7 +1852,7 @@ void print_x2A(const void *untyped_inst, File<version> *fs, const int d) {
 
 template <AllegroVersion version>
 void print_x2B(const void *untyped_inst, File<version> *fs, const int d) {
-  const x2B<version> *inst = (const x2B<version> *)untyped_inst;
+  const T2BSymbol<version> *inst = (const T2BSymbol<version> *)untyped_inst;
   printf_d(d,
            "x2B: t=0x%08X k=0x%08X"
            " \x1b[34m\"%s\"\x1b[0m"

--- a/src/lib/structure/types.cpp
+++ b/src/lib/structure/types.cpp
@@ -544,8 +544,8 @@ T28Shape<kA160>::operator T28Shape<kAMax>() const {
 }
 
 template <>
-x2B<kA160>::operator x2B<kAMax>() const {
-  x2B<kAMax> new_inst;
+T2BSymbol<kA160>::operator T2BSymbol<kAMax>() const {
+  T2BSymbol<kAMax> new_inst;
   new_inst.t = this->t;
   new_inst.k = this->k;
   new_inst.un1 = this->un1;
@@ -566,8 +566,8 @@ x2B<kA160>::operator x2B<kAMax>() const {
 }
 
 template <>
-x2B<kA164>::operator x2B<kAMax>() const {
-  x2B<kAMax> new_inst;
+T2BSymbol<kA164>::operator T2BSymbol<kAMax>() const {
+  T2BSymbol<kAMax> new_inst;
   new_inst.t = this->t;
   new_inst.k = this->k;
   new_inst.un1 = this->un1;
@@ -969,7 +969,7 @@ void File<version>::cache_upgrade_funcs() {
       this->x24_upgrade = new_upgrade<kA160, kAMax, x24>;
       this->x26_upgrade = new_upgrade<kA160, kAMax, x26>;
       this->x28_upgrade = new_upgrade<kA160, kAMax, T28Shape>;
-      this->x2B_upgrade = new_upgrade<kA160, kAMax, x2B>;
+      this->x2B_upgrade = new_upgrade<kA160, kAMax, T2BSymbol>;
       this->x2C_upgrade = new_upgrade<kA160, kAMax, x2C>;
       this->x2D_upgrade = new_upgrade<kA160, kAMax, T2DSymbolInstance>;
       this->x2E_upgrade = new_upgrade<kA160, kAMax, x2E>;
@@ -1011,7 +1011,7 @@ void File<version>::cache_upgrade_funcs() {
       this->x24_upgrade = new_upgrade<kA162, kAMax, x24>;
       this->x26_upgrade = new_upgrade<kA162, kAMax, x26>;
       this->x28_upgrade = new_upgrade<kA162, kAMax, T28Shape>;
-      this->x2B_upgrade = new_upgrade<kA162, kAMax, x2B>;
+      this->x2B_upgrade = new_upgrade<kA162, kAMax, T2BSymbol>;
       this->x2C_upgrade = new_upgrade<kA162, kAMax, x2C>;
       this->x2D_upgrade = new_upgrade<kA162, kAMax, T2DSymbolInstance>;
       this->x2E_upgrade = new_upgrade<kA162, kAMax, x2E>;
@@ -1053,7 +1053,7 @@ void File<version>::cache_upgrade_funcs() {
       this->x24_upgrade = new_upgrade<kA164, kAMax, x24>;
       this->x26_upgrade = new_upgrade<kA164, kAMax, x26>;
       this->x28_upgrade = new_upgrade<kA164, kAMax, T28Shape>;
-      this->x2B_upgrade = new_upgrade<kA164, kAMax, x2B>;
+      this->x2B_upgrade = new_upgrade<kA164, kAMax, T2BSymbol>;
       this->x2C_upgrade = new_upgrade<kA164, kAMax, x2C>;
       this->x2D_upgrade = new_upgrade<kA164, kAMax, T2DSymbolInstance>;
       this->x2E_upgrade = new_upgrade<kA164, kAMax, x2E>;
@@ -1095,7 +1095,7 @@ void File<version>::cache_upgrade_funcs() {
       this->x24_upgrade = new_upgrade<kA165, kAMax, x24>;
       this->x26_upgrade = new_upgrade<kA165, kAMax, x26>;
       this->x28_upgrade = new_upgrade<kA165, kAMax, T28Shape>;
-      this->x2B_upgrade = new_upgrade<kA165, kAMax, x2B>;
+      this->x2B_upgrade = new_upgrade<kA165, kAMax, T2BSymbol>;
       this->x2C_upgrade = new_upgrade<kA165, kAMax, x2C>;
       this->x2D_upgrade = new_upgrade<kA165, kAMax, T2DSymbolInstance>;
       this->x2E_upgrade = new_upgrade<kA165, kAMax, x2E>;
@@ -1138,7 +1138,7 @@ void File<version>::cache_upgrade_funcs() {
       this->x24_upgrade = new_upgrade<kA166, kAMax, x24>;
       this->x26_upgrade = new_upgrade<kA166, kAMax, x26>;
       this->x28_upgrade = new_upgrade<kA166, kAMax, T28Shape>;
-      this->x2B_upgrade = new_upgrade<kA166, kAMax, x2B>;
+      this->x2B_upgrade = new_upgrade<kA166, kAMax, T2BSymbol>;
       this->x2C_upgrade = new_upgrade<kA166, kAMax, x2C>;
       this->x2D_upgrade = new_upgrade<kA166, kAMax, T2DSymbolInstance>;
       this->x2E_upgrade = new_upgrade<kA166, kAMax, x2E>;
@@ -1185,7 +1185,7 @@ void File<version>::cache_upgrade_funcs() {
       this->x24_upgrade = new_upgrade<kA172, kAMax, x24>;
       this->x26_upgrade = new_upgrade<kA172, kAMax, x26>;
       this->x28_upgrade = new_upgrade<kA172, kAMax, T28Shape>;
-      this->x2B_upgrade = new_upgrade<kA172, kAMax, x2B>;
+      this->x2B_upgrade = new_upgrade<kA172, kAMax, T2BSymbol>;
       this->x2C_upgrade = new_upgrade<kA172, kAMax, x2C>;
       this->x2D_upgrade = new_upgrade<kA172, kAMax, T2DSymbolInstance>;
       this->x2E_upgrade = new_upgrade<kA172, kAMax, x2E>;
@@ -1230,7 +1230,7 @@ void File<version>::cache_upgrade_funcs() {
       this->x24_upgrade = new_upgrade<kA174, kAMax, x24>;
       this->x26_upgrade = new_upgrade<kA174, kAMax, x26>;
       this->x28_upgrade = new_upgrade<kA174, kAMax, T28Shape>;
-      this->x2B_upgrade = new_upgrade<kA174, kAMax, x2B>;
+      this->x2B_upgrade = new_upgrade<kA174, kAMax, T2BSymbol>;
       this->x2C_upgrade = new_upgrade<kA174, kAMax, x2C>;
       this->x2D_upgrade = new_upgrade<kA174, kAMax, T2DSymbolInstance>;
       this->x2E_upgrade = new_upgrade<kA174, kAMax, x2E>;
@@ -1272,7 +1272,7 @@ void File<version>::cache_upgrade_funcs() {
       this->x24_upgrade = new_upgrade<kAMax, kAMax, x24>;
       this->x26_upgrade = new_upgrade<kAMax, kAMax, x26>;
       this->x28_upgrade = new_upgrade<kAMax, kAMax, T28Shape>;
-      this->x2B_upgrade = new_upgrade<kAMax, kAMax, x2B>;
+      this->x2B_upgrade = new_upgrade<kAMax, kAMax, T2BSymbol>;
       this->x2C_upgrade = new_upgrade<kAMax, kAMax, x2C>;
       this->x2D_upgrade = new_upgrade<kAMax, kAMax, T2DSymbolInstance>;
       this->x2E_upgrade = new_upgrade<kAMax, kAMax, x2E>;
@@ -1511,7 +1511,7 @@ const T28Shape<kAMax> File<kAMax>::get_x28(uint32_t k) {
 }
 
 template <>
-const x2B<kAMax> File<kAMax>::get_x2B(uint32_t k) {
+const T2BSymbol<kAMax> File<kAMax>::get_x2B(uint32_t k) {
   return this->x2B_upgrade(this->ptrs[k]);
 }
 

--- a/src/lib/structure/types.h
+++ b/src/lib/structure/types.h
@@ -1101,7 +1101,7 @@ struct T2ACustomLayer {
 };
 
 template <AllegroVersion version>
-struct x2B {
+struct T2BSymbol {
   uint32_t t;
   uint32_t k;
   uint32_t footprint_string_ref;
@@ -1143,7 +1143,7 @@ struct x2B {
   COND_FIELD(version >= kA172, uint32_t, un3);
 
   uint32_t TAIL;
-  operator x2B<kAMax>() const;
+  operator T2BSymbol<kAMax>() const;
   static constexpr AllegroVersion versions[2] = {kA164, kA172};
 };
 
@@ -1672,7 +1672,7 @@ class File {
   const x24<kAMax> get_x24(uint32_t k);
   const x26<kAMax> get_x26(uint32_t k);
   const T28Shape<kAMax> get_x28(uint32_t k);
-  const x2B<kAMax> get_x2B(uint32_t k);
+  const T2BSymbol<kAMax> get_x2B(uint32_t k);
   const x2C<kAMax> get_x2C(uint32_t k);
   const T2DSymbolInstance<kAMax> get_x2D(uint32_t k);
   const x2E<kAMax> get_x2E(uint32_t k);
@@ -1804,15 +1804,17 @@ class File {
         Iter<T1CPad<version>>(*this, this->hdr->ll_x1C.tail, &File::get_x1C));
   };
 
-  IterBase<x2B<version>> iter_x2B() {
+  IterBase<T2BSymbol<version>> iter_x2B() {
     if (this->hdr->ll_x2B.head == 0) {
-      return IterBase<x2B<version>>(
-          Iter<x2B<version>>(*this, 0, &File::get_x2B),
-          Iter<x2B<version>>(*this, 0, &File::get_x2B));
+      return IterBase<T2BSymbol<version>>(
+          Iter<T2BSymbol<version>>(*this, 0, &File::get_x2B),
+          Iter<T2BSymbol<version>>(*this, 0, &File::get_x2B));
     } else {
-      return IterBase<x2B<version>>(
-          Iter<x2B<version>>(*this, this->hdr->ll_x2B.head, &File::get_x2B),
-          Iter<x2B<version>>(*this, this->hdr->ll_x2B.tail, &File::get_x2B));
+      return IterBase<T2BSymbol<version>>(
+          Iter<T2BSymbol<version>>(*this, this->hdr->ll_x2B.head,
+                                   &File::get_x2B),
+          Iter<T2BSymbol<version>>(*this, this->hdr->ll_x2B.tail,
+                                   &File::get_x2B));
     }
   };
 
@@ -1928,7 +1930,7 @@ class File {
   x24<kAMax> (*x24_upgrade)(void *);
   x26<kAMax> (*x26_upgrade)(void *);
   T28Shape<kAMax> (*x28_upgrade)(void *);
-  x2B<kAMax> (*x2B_upgrade)(void *);
+  T2BSymbol<kAMax> (*x2B_upgrade)(void *);
   x2C<kAMax> (*x2C_upgrade)(void *);
   T2DSymbolInstance<kAMax> (*x2D_upgrade)(void *);
   x2E<kAMax> (*x2E_upgrade)(void *);

--- a/src/lib/structure/utils.h
+++ b/src/lib/structure/utils.h
@@ -37,7 +37,7 @@ const std::string x03_str_lookup(uint32_t id, File<version> &fs) {
 }
 
 template <AllegroVersion version>
-std::optional<std::string> x2B_footprint(const x2B<version> *inst,
+std::optional<std::string> x2B_footprint(const T2BSymbol<version> *inst,
                                          File<version> *fs) {
   if (fs->strings.count(inst->footprint_string_ref) > 0) {
     return fs->strings.at(inst->footprint_string_ref);
@@ -57,7 +57,7 @@ std::optional<std::string> x2B_refdes(const uint32_t k, File<version> *fs) {
     return std::optional<std::string>();
   }
 
-  const x2B<version> &inst = fs->get_x2B(k);
+  const T2BSymbol<version> &inst = fs->get_x2B(k);
   return x2D_refdes(inst.ptr2, fs);
 }
 

--- a/src/test/test_helpers.impl.h
+++ b/src/test/test_helpers.impl.h
@@ -101,7 +101,7 @@ void validate_x28(const T28Shape<version>& i, File<version>& fs) {
 }
 
 template <AllegroVersion version>
-void validate_x2B(const x2B<version>& i, File<version>& fs) {
+void validate_x2B(const T2BSymbol<version>& i, File<version>& fs) {
   if (i.next != fs.hdr->ll_x2B.tail) {
     EXPECT_TRUE(CheckType(i, i.next, fs));
   }


### PR DESCRIPTION
Consistent with other renaming recently, to match Google style