### PR TITLE
Fix missing shapes found in header linked list pointers

### DIFF
--- a/src/brd_cli/main.cpp
+++ b/src/brd_cli/main.cpp
@@ -86,7 +86,7 @@ int main(int argc, char* argv[]) {
     } else if (parsed_file->is_type(k, 0x28)) {
       auto& i = parsed_file->get_x28(k);
       printf("Found x28 w/ key = 0x %08X\n", ntohl(k));
-      k = i.ptr1;
+      k = i.next;
     } else if (parsed_file->is_type(k, 0x24)) {
       auto& i = parsed_file->get_x24(k);
       printf("Found x24 w/ key = 0x %08X\n", ntohl(k));

--- a/src/brd_gui/brdview.cpp
+++ b/src/brd_gui/brdview.cpp
@@ -780,7 +780,7 @@ void BrdView::drawFile() {
         } else if (fs->is_type(k, 0x28)) {
           auto &x = fs->get_x28(k);
           drawShape(x.k, pen2);
-          k = x.un1;
+          k = x.next;
         } else if (fs->is_type(k, 0x1B)) {
           break;
         } else if (fs->is_type(k, 0x0E)) {
@@ -867,6 +867,24 @@ void BrdView::drawFile() {
       drawShape(i_x03_x30.k, pen2);
     }
   }
+
+  // Draw some additional shapes in an extra linked list
+  LinkedListPtrs text_ll = fs->hdr->ll_x24_x28;
+  uint32_t k = text_ll.head;
+  while (k != text_ll.tail) {
+    if (fs->is_type(k, 0x28)) {
+      auto &i = fs->get_x28(k);
+      drawShape(k, pen4);
+      k = i.next;
+    } else if (fs->is_type(k, 0x24)) {
+      auto &i = fs->get_x24(k);
+      k = i.un[0];
+    } else {
+      qDebug() << "Unexpected end of list?";
+      break;
+    }
+  }
+
   // for (const auto &[k, x30_inst] : fs->x30_map) {
   //     drawShape(k, pen2);
   // }

--- a/src/brd_gui/test/brdview_test.cpp
+++ b/src/brd_gui/test/brdview_test.cpp
@@ -15,8 +15,11 @@ void TestBrdView::drawAllSymbolPaths() {
   brdview.selectLayer(layers);
 
   // If we don't iterate over all symbol paths, we miss this one.
-  QVERIFY2(brdview.drewKey(0x000055F6),
-           "Path unexpectedly missing after selecting its layer");
+  QVERIFY2(brdview.drewKey(0x000055F6), "Path unexpectedly missing");
+
+  // If we don't look through the x24/x28 linked list in the header, we will
+  // miss this shape.
+  QVERIFY2(brdview.drewKey(0x000016D4), "Shape unexpectedly missing");
 }
 
 QTEST_MAIN(TestBrdView)

--- a/src/lib/printing/printers.cpp
+++ b/src/lib/printing/printers.cpp
@@ -1701,16 +1701,16 @@ void print_x28(const void *untyped_inst, File<version> *fs, const int d) {
     }
   }
 
-  if (inst.next != 0) {
+  if (inst.ptr2 != 0) {
     printf_d(d + 1, "next:\n");
-    if (fs->is_type(inst.next, 0x28)) {
-      print_struct(inst.next, *fs, d + 2);
-    } else if (fs->is_type(inst.next, 0x33)) {
-      print_struct(inst.next, *fs, d + 2);
-    } else if (fs->is_type(inst.next, 0x2D)) {
-      print_struct(inst.next, *fs, d + 2);
+    if (fs->is_type(inst.ptr2, 0x28)) {
+      print_struct(inst.ptr2, *fs, d + 2);
+    } else if (fs->is_type(inst.ptr2, 0x33)) {
+      print_struct(inst.ptr2, *fs, d + 2);
+    } else if (fs->is_type(inst.ptr2, 0x2D)) {
+      print_struct(inst.ptr2, *fs, d + 2);
     } else {
-      printf_d(d + 2, "next unrecognized: 0x%08X\n", ntohl(inst.next));
+      printf_d(d + 2, "next unrecognized: 0x%08X\n", ntohl(inst.ptr2));
       exit(0);
     }
   }

--- a/src/lib/structure/types.cpp
+++ b/src/lib/structure/types.cpp
@@ -526,10 +526,10 @@ T28Shape<kA160>::operator T28Shape<kAMax>() const {
   new_inst.layer = this->layer;
 
   new_inst.k = this->k;
-  new_inst.un1 = this->un1;
+  new_inst.next = this->next;
   new_inst.ptr1 = this->ptr1;
   new_inst.un2 = this->un2;
-  new_inst.next = this->next;
+  new_inst.ptr2 = this->ptr2;
   new_inst.ptr3 = this->ptr3;
   new_inst.ptr4 = this->ptr4;
   new_inst.first_segment_ptr = this->first_segment_ptr;

--- a/src/lib/structure/types.h
+++ b/src/lib/structure/types.h
@@ -1009,7 +1009,7 @@ struct T28Shape {
   uint8_t layer;
 
   uint32_t k;
-  uint32_t un1;
+  uint32_t next;
 
   // Points to one of: header value, `x04`, `x2B`, `x2D`
   uint32_t ptr1;
@@ -1020,7 +1020,7 @@ struct T28Shape {
   COND_FIELD(version >= kA172, uint32_t[2], un5);
 
   // Points to `x28`, `x2D`, or `x33`
-  uint32_t next;
+  uint32_t ptr2;
 
   // Points to `x05` or `x09` (much more frequently `x09`)
   uint32_t ptr3;


### PR DESCRIPTION
Some shapes are in a linked list pointed from the header. This makes sure they're drawn, also.

Some board outlines are in this header.