### PR TITLE
Do not rotate text in drill symbols

### DIFF
--- a/src/brd_gui/brdview.cpp
+++ b/src/brd_gui/brdview.cpp
@@ -210,7 +210,6 @@ void BrdView::drawX0C(const T0CDrillIndicator<kAMax> *inst, QPen *pen) {
     QTransform t =
         QTransform()
             .translate(center.x(), center.y())
-            .rotate(inst->rotation / 1000.)
             .scale(1, -1)
             .translate(boundingBox.width() * -0.5, boundingBox.height() * -0.5);
 


### PR DESCRIPTION
It's difficult to see, but it looks like drill tables don't have rotated text when the drill itself is rotated.

This example is from the BeagleY-AI gerbers:

<img width="197" alt="Screenshot 2024-06-16 at 10 01 50 PM" src="https://github.com/jeffwheeler/brd_parser/assets/14618/a609a155-1743-4a7c-afa4-2d9f8e4b87f5">